### PR TITLE
Update util.js

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -1,7 +1,7 @@
 
 
 var _ = require('underscore');
-
+var DataObjectParser = require('dataobject-parser');
 
 /*
 * Function to verify watchers
@@ -138,7 +138,7 @@ module.exports = {
     esClient.delete({
       index: watcher.index,
       type: watcher.type,
-      id: id
+      id: id.toString()
     }, function (error, response) {
       if (error) {
         console.log('ESMongoSync: Not Found - ', 'Document with id ' + id + ' not found.');
@@ -156,9 +156,9 @@ module.exports = {
     esClient.update({
       index: watcher.index,
       type: watcher.type,
-      id: id,
+      id: id.toString,
       body: {
-        doc: partialDocument
+        doc: DataObjectParser(partialDocument)._data
       }
     }, function (error) {
       if (!error) {


### PR DESCRIPTION
convert id field to a string when updating or deleting, also convert any dotted field names to nested JSON object which i believe is no longer supported in elastic search ie( {"details.id" :"1234"} will be converted to {"Details" :{"id" :"1234"}} ).  This is done by adding the npm module DataObject-parser.
