### PR TITLE
Document id is undefined before transformation

### DIFF
--- a/lib/util/crud.js
+++ b/lib/util/crud.js
@@ -28,7 +28,7 @@ module.exports = {
    * @return {null} return null
    */
   insert: function (watcher, document, esClient) {
-    debugElasticsearch('Inserting document %s', document.id.toString());
+    debugElasticsearch('Inserting document %s', document._id.toString());
     Util.transform(watcher, document, function (document) {
       esClient.index({
         index: watcher.index,


### PR DESCRIPTION
The debug statement crashes the insert because the document._id is not yet transformed to document.id.